### PR TITLE
Added 3DSECURE

### DIFF
--- a/Client/Response.php
+++ b/Client/Response.php
@@ -17,21 +17,29 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  */
 class Response
 {
+    private $secure;
     public $body;
 
-    public function __construct(array $parameters)
+    /**
+     * Creates a new response.
+     *
+     * @param array   $parameters An array of parameters
+     * @param boolean $secure     True if 3DS was used for the request
+     */
+    public function __construct(array $parameters, $secure = false)
     {
         $this->body = new ParameterBag($parameters);
+        $this->secure = $secure;
     }
 
     public function getOperationType()
     {
-        return $this->body->get('OPERATIONTYPE', null);
+        return $this->body->get('OPERATIONTYPE');
     }
 
     public function getTransactionId()
     {
-        return $this->body->get('TRANSACTIONID', null);
+        return $this->body->get('TRANSACTIONID');
     }
 
     public function getExecutionCode()
@@ -44,19 +52,28 @@ class Response
         return $this->body->get('MESSAGE');
     }
 
+    public function getSecureHtml()
+    {
+        return $this->body->get('3DSECUREHTML');
+    }
+
+    public function isSecure()
+    {
+        return $this->secure;
+    }
+
     public function isSuccess()
     {
+        if ($this->secure) {
+            return '0001' == $this->getExecutionCode();
+        }
+
         return '0000' == $this->getExecutionCode();
     }
 
     public function isError()
     {
-        return !$this->isSuccess();
-    }
-
-    public function is3dSecureError()
-    {
-        return '0001' == $this->getExecutionCode();
+        return !$this->isSuccess($this->secure);
     }
 
     public function isValidationError()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,13 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
                     ->scalarNode('identifier')->isRequired()->cannotBeEmpty()->end()
                     ->scalarNode('password')->isRequired()->cannotBeEmpty()->end()
+                    ->scalarNode('default_3ds_display_mode')
+                        ->defaultValue('main')
+                        ->validate()
+                            ->ifNotInArray(array('main', 'popup', 'top'))
+                            ->thenInvalid('Invalid 3d secure display mode "%s"')
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/RezzzaPaymentBe2billExtension.php
+++ b/DependencyInjection/RezzzaPaymentBe2billExtension.php
@@ -37,5 +37,6 @@ class RezzzaPaymentBe2billExtension extends Extension
         $container->setParameter('payment.be2bill.debug', $config['debug']);
         $container->setParameter('payment.be2bill.identifier', $config['identifier']);
         $container->setParameter('payment.be2bill.password', $config['password']);
+        $container->setParameter('payment.be2bill.default_3ds_display_mode', $config['default_3ds_display_mode']);
     }
 }

--- a/Plugin/Be2billDirectLinkPlugin.php
+++ b/Plugin/Be2billDirectLinkPlugin.php
@@ -7,6 +7,7 @@ use JMS\Payment\CoreBundle\Plugin\Exception\FinancialException;
 use JMS\Payment\CoreBundle\Model\FinancialTransactionInterface;
 use JMS\Payment\CoreBundle\Plugin\AbstractPlugin;
 use Rezzza\PaymentBe2billBundle\Client\Client;
+use Rezzza\PaymentBe2billBundle\Plugin\Exception\SecureActionRequiredException;
 
 /**
  * This file is part of the RezzzaPaymentBe2billBundle package.
@@ -65,6 +66,13 @@ class Be2billDirectLinkPlugin extends AbstractPlugin
             $exception->setFinancialTransaction($transaction);
             $transaction->setResponseCode($response->getExecutionCode());
             $transaction->setReasonCode($response->getMessage());
+
+            throw $exception;
+        }
+
+        if ($response->isSecure()) {
+            $exception = new SecureActionRequiredException(sprintf('Deposit : transaction "%s" waits approval by 3DS', $response->getTransactionId()));
+            $exception->setHtml($response->getSecureHtml());
 
             throw $exception;
         }

--- a/Plugin/Exception/SecureActionRequiredException.php
+++ b/Plugin/Exception/SecureActionRequiredException.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Plugin\Exception;
+
+use JMS\Payment\CoreBundle\Plugin\Exception\ActionRequiredException;
+
+/**
+ * This file is part of the RezzzaPaymentBe2billBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+/**
+ * This exception is thrown when the transaction is secured by 3DS
+ * and the user needs to perform an action (eg. enter his pin code).
+ * The HTML (base64 encoded) needed to display the form can be accessed with getHtml().
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class SecureActionRequiredException extends ActionRequiredException
+{
+    private $html;
+
+    /**
+     * Sets the html for the form.
+     *
+     * @param string $html
+     */
+    public function setHtml($html)
+    {
+        $this->html = $html;
+    }
+
+    /**
+     * Gets the html.
+     *
+     * @return string
+     */
+    public function getHtml()
+    {
+        return $this->html;
+    }
+}

--- a/Resources/config/client.xml
+++ b/Resources/config/client.xml
@@ -13,6 +13,7 @@
             <argument>%payment.be2bill.identifier%</argument>
             <argument>%payment.be2bill.password%</argument>
             <argument>%payment.be2bill.debug%</argument>
+            <argument>%payment.be2bill.default_3ds_display_mode%</argument>
         </service>
 
     </services>

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -26,13 +26,13 @@ class Client extends atoum\test
     public function testConstruct()
     {
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->boolean($client->getDebug())
                     ->isFalse()
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', true))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', true, 'main'))
                 ->boolean($client->getDebug())
                     ->isTrue()
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->boolean($client->getDebug())
                     ->isFalse()
         ;
@@ -41,7 +41,7 @@ class Client extends atoum\test
     public function testSetDebug()
     {
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->boolean($client->getDebug())
                     ->isFalse()
             ->if($client->setDebug(true))
@@ -66,7 +66,7 @@ class Client extends atoum\test
         );
 
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->array($client->getApiEndpoints(false))
                     ->isIdenticalTo($apiEndPoints['production'])
             ->if($client->setDebug(true))
@@ -78,7 +78,7 @@ class Client extends atoum\test
     public function testSortParameters()
     {
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
             ->and($parameters = array(
                 'CLIENTIDENT'      => '404',
                 'CLIENTREFERRER'   => 'example.org',
@@ -118,10 +118,10 @@ class Client extends atoum\test
     public function testConvertAmountToBe2billFormat()
     {
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->integer($amount = $client->convertAmountToBe2billFormat('23.99'))
                     ->isIdenticalTo(2399)
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
                 ->integer($client->convertAmountToBe2billFormat('23'))
                     ->isIdenticalTo(2300)
         ;
@@ -130,13 +130,52 @@ class Client extends atoum\test
     public function testGetSignature()
     {
         $this
-            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache'))
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
             ->and($parameters = array(
                 'CLIENTREFERRER'=> 'example.org',
                 'CLIENTIDENT'   => '404',
             ))
                 ->string($client->getSignature('CuirMoustache', $parameters))
                     ->isIdenticalTo(hash('sha256', 'CuirMoustacheCLIENTIDENT=404CuirMoustacheCLIENTREFERRER=example.orgCuirMoustache'))
+        ;
+    }
+
+    public function testConfigure3dsParametersUnsupportedOperation()
+    {
+        $this
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
+            ->and($parameters = array('3DSECURE' => 'yes', '3DSECUREDISPLAYMODE' => 'main'))
+            ->and($parameters = $client->configureParameters('invalid', $parameters))
+                ->array($params = $parameters['params'])
+                    ->notHasKeys(array('3DSECURE', '3DSECUREDISPLAYMODE'))
+        ;
+    }
+
+    public function testConfigure3dsParameters()
+    {
+        $this
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
+            ->and($parameters = array('3DSECURE' => 'yes', '3DSECUREDISPLAYMODE' => 'top'))
+            ->and($parameters = $client->configureParameters('payment', $parameters))
+            ->and($params = $parameters['params'])
+                ->string($params['3DSECURE'])
+                    ->isEqualTo('yes')
+                ->string($params['3DSECUREDISPLAYMODE'])
+                    ->isEqualTo('top')
+        ;
+    }
+
+    public function testConfigure3dsParametersDefaultMode()
+    {
+        $this
+            ->if($client = new TestedClient('CHUCKNORRIS', 'CuirMoustache', false, 'main'))
+            ->and($parameters = array('3DSECURE' => 'yes'))
+            ->and($parameters = $client->configureParameters('payment', $parameters))
+            ->and($params = $parameters['params'])
+                ->string($params['3DSECURE'])
+                    ->isEqualTo('yes')
+                ->string($params['3DSECUREDISPLAYMODE'])
+                    ->isEqualTo('main')
         ;
     }
 }

--- a/Tests/Units/Client/Response.php
+++ b/Tests/Units/Client/Response.php
@@ -61,6 +61,15 @@ class Response extends atoum\test
         ;
     }
 
+    public function testGetSecureHtml()
+    {
+        $this
+            ->if($response = new TestedResponse(array('3DSECUREHTML' => '<html></html>')))
+                ->string($response->getSecureHtml())
+                    ->isIdenticalTo('<html></html>')
+        ;
+    }
+
     public function testGetMessage()
     {
         $this
@@ -82,6 +91,12 @@ class Response extends atoum\test
             ->if($response = new TestedResponse(array()))
                 ->boolean($response->isSuccess())
                     ->isFalse()
+            ->if($response = new TestedResponse(array('EXECCODE' => '0001'), true))
+                ->boolean($response->isSuccess())
+                    ->isTrue()
+            ->if($response = new TestedResponse(array('EXECCODE' => '0000'), true))
+                ->boolean($response->isSuccess())
+                    ->isFalse()
         ;
     }
 
@@ -97,20 +112,11 @@ class Response extends atoum\test
             ->if($response = new TestedResponse(array()))
                 ->boolean($response->isError())
                     ->isTrue()
-        ;
-    }
-
-    public function testIs3dSecureError()
-    {
-        $this
-            ->if($response = new TestedResponse(array('EXECCODE' => '0001')))
-                ->boolean($response->is3dSecureError())
+            ->if($response = new TestedResponse(array('EXECCODE' => '0000'), true))
+                ->boolean($response->isError())
                     ->isTrue()
-            ->if($response = new TestedResponse(array('EXECCODE' => '0000')))
-                ->boolean($response->is3dSecureError())
-                    ->isFalse()
-            ->if($response = new TestedResponse(array()))
-                ->boolean($response->is3dSecureError())
+            ->if($response = new TestedResponse(array('EXECCODE' => '0001'), true))
+                ->boolean($response->isError())
                     ->isFalse()
         ;
     }
@@ -229,6 +235,21 @@ class Response extends atoum\test
                     ->isInstanceOf('Symfony\Component\HttpFoundation\ParameterBag')
                 ->array($response->toArray())
                     ->isIdenticalTo(array('chuck' => 'norris'))
+        ;
+    }
+
+    public function testIsSecure()
+    {
+        $this
+            ->if($response = new TestedResponse(array()))
+                ->boolean($response->isSecure())
+                    ->isFalse()
+            ->if($response = new TestedResponse(array(), false))
+                ->boolean($response->isSecure())
+                    ->isFalse()
+            ->if($response = new TestedResponse(array(), true))
+                ->boolean($response->isSecure())
+                    ->isTrue()
         ;
     }
 

--- a/Tests/Units/DependencyInjection/RezzzaPaymentBe2billExtension.php
+++ b/Tests/Units/DependencyInjection/RezzzaPaymentBe2billExtension.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Tests\Units\DependencyInjection;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+use mageekguy\atoum;
+use Rezzza\PaymentBe2billBundle\DependencyInjection\RezzzaPaymentBe2billExtension as TestedExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * This file is part of the RezzzaPaymentBe2billBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+/**
+ * RezzzaPaymentBe2billExtension.
+ *
+ * @uses atoum\test
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class RezzzaPaymentBe2billExtension extends atoum\test
+{
+    public function testCreateClientDefaultDisplayMode()
+    {
+        $this
+            ->if($container = new ContainerBuilder())
+            ->and($extension = new TestedExtension())
+            ->and($config = array('rezzza_payment_be2bill' =>
+                array('identifier' => 'test', 'password' => 'test')
+            ))
+            ->and($extension->load($config, $container))
+                ->string($container->getParameter('payment.be2bill.identifier'))
+                    ->isEqualTo('test')
+                ->string($container->getParameter('payment.be2bill.password'))
+                    ->isEqualTo('test')
+                ->string($container->getParameter('payment.be2bill.default_3ds_display_mode'))
+                    ->isEqualTo('main')
+        ;
+    }
+
+    public function testCreateCient()
+    {
+        $this
+            ->if($container = new ContainerBuilder())
+            ->and($extension = new TestedExtension())
+            ->and($config = array('rezzza_payment_be2bill' =>
+                array('identifier' => 'test', 'password' => 'test', 'default_3ds_display_mode' => 'popup')
+            ))
+            ->and($extension->load($config, $container))
+                ->string($container->getParameter('payment.be2bill.identifier'))
+                    ->isEqualTo('test')
+                ->string($container->getParameter('payment.be2bill.password'))
+                    ->isEqualTo('test')
+                ->string($container->getParameter('payment.be2bill.default_3ds_display_mode'))
+                    ->isEqualTo('popup')
+        ;
+    }
+
+    public function testCreateCientInvalidDisplayMode()
+    {
+        $this
+            ->if($container = new ContainerBuilder())
+            ->and($config = array('rezzza_payment_be2bill' =>
+                array('identifier' => 'test', 'password' => 'test', 'default_3ds_display_mode' => 'INVALID')
+            ))
+            ->and($extension = new TestedExtension())
+                ->exception(function () use ($extension, $config, $container) {
+                    $extension->load($config, $container);
+                })
+        ;
+    }
+}


### PR DESCRIPTION
This should fix issue https://github.com/rezzza/PaymentBe2billBundle/issues/16.

The default display mode for 3DS can be configured in the bundle (defaults to `main`):

``` yaml
rezzza_payment_be2bill:
    default_3ds_display_mode: main / top / popup
```

To use 3DSecure, extra data parameters can be added to the payment https://github.com/rezzza/payment.vlr/blob/master/src/Vlr/ChargeBundle/Backend/Be2bill.php#L99.
- `3DSECURE` = `yes` (required to enable 3DS)
- `3DSECUREDISPLAYMODE` = `main` / `top` / `popup` (optional, will default to the Bundle configuration)

When the deposit is made, if the transaction is secure, it will throw a `SecureActionRequiredException` that will be caught by the Plugin controller https://github.com/schmittjoh/JMSPaymentCoreBundle/blob/master/PluginController/PluginController.php#L403-L420. The transaction will be pending until the callback is received.

The html needed to display the form can then be accessed with:

``` php
$html = $result->getPluginException()->getHtml();
```
