### PR TITLE
Fixed an issue when an action is required by 3DS

### DIFF
--- a/Client/Response.php
+++ b/Client/Response.php
@@ -57,18 +57,20 @@ class Response
         return $this->body->get('3DSECUREHTML');
     }
 
-    public function isSecure()
+    /**
+     * Tells if an action needs to be performed by the user
+     * in the context of a 3DS transaction.
+     *
+     * @return boolean
+     */
+    public function isSecureActionRequired()
     {
-        return $this->secure;
+        return $this->secure && '0001' === $this->getExecutionCode();
     }
 
     public function isSuccess()
     {
-        if ($this->secure) {
-            return '0001' == $this->getExecutionCode();
-        }
-
-        return '0000' == $this->getExecutionCode();
+        return '0000' === $this->getExecutionCode();
     }
 
     public function isError()

--- a/Plugin/Be2billDirectLinkPlugin.php
+++ b/Plugin/Be2billDirectLinkPlugin.php
@@ -61,18 +61,18 @@ class Be2billDirectLinkPlugin extends AbstractPlugin
 
         $transaction->setTrackingId($response->getTransactionId());
 
+        if ($response->isSecureActionRequired()) {
+            $exception = new SecureActionRequiredException(sprintf('Deposit : transaction "%s" waits approval by 3DS', $response->getTransactionId()));
+            $exception->setHtml($response->getSecureHtml());
+
+            throw $exception;
+        }
+
         if (!$response->isSuccess()) {
             $exception = new FinancialException(sprintf('Deposit : transaction "%s" is not valid', $response->getTransactionId()));
             $exception->setFinancialTransaction($transaction);
             $transaction->setResponseCode($response->getExecutionCode());
             $transaction->setReasonCode($response->getMessage());
-
-            throw $exception;
-        }
-
-        if ($response->isSecure()) {
-            $exception = new SecureActionRequiredException(sprintf('Deposit : transaction "%s" waits approval by 3DS', $response->getTransactionId()));
-            $exception->setHtml($response->getSecureHtml());
 
             throw $exception;
         }

--- a/Tests/Units/Client/Response.php
+++ b/Tests/Units/Client/Response.php
@@ -93,10 +93,10 @@ class Response extends atoum\test
                     ->isFalse()
             ->if($response = new TestedResponse(array('EXECCODE' => '0001'), true))
                 ->boolean($response->isSuccess())
-                    ->isTrue()
+                    ->isFalse()
             ->if($response = new TestedResponse(array('EXECCODE' => '0000'), true))
                 ->boolean($response->isSuccess())
-                    ->isFalse()
+                    ->isTrue()
         ;
     }
 
@@ -114,10 +114,10 @@ class Response extends atoum\test
                     ->isTrue()
             ->if($response = new TestedResponse(array('EXECCODE' => '0000'), true))
                 ->boolean($response->isError())
-                    ->isTrue()
-            ->if($response = new TestedResponse(array('EXECCODE' => '0001'), true))
-                ->boolean($response->isError())
                     ->isFalse()
+            ->if($response = new TestedResponse(array('EXECCODE' => '9999'), true))
+                ->boolean($response->isError())
+                    ->isTrue()
         ;
     }
 
@@ -238,17 +238,17 @@ class Response extends atoum\test
         ;
     }
 
-    public function testIsSecure()
+    public function testIsSecureActionRequired()
     {
         $this
-            ->if($response = new TestedResponse(array()))
-                ->boolean($response->isSecure())
+            ->if($response = new TestedResponse(array('EXECCODE' => '0001')))
+                ->boolean($response->isSecureActionRequired())
                     ->isFalse()
-            ->if($response = new TestedResponse(array(), false))
-                ->boolean($response->isSecure())
+            ->if($response = new TestedResponse(array('EXECCODE' => '0000'), true))
+                ->boolean($response->isSecureActionRequired())
                     ->isFalse()
-            ->if($response = new TestedResponse(array(), true))
-                ->boolean($response->isSecure())
+            ->if($response = new TestedResponse(array('EXECCODE' => '0001'), true))
+                ->boolean($response->isSecureActionRequired())
                     ->isTrue()
         ;
     }


### PR DESCRIPTION
I added a new method `isSecureActionRequired` which is clearer and reverted `isSuccess` which will return true only when the code is `0000` (no matter if 3DS is used).
It also fixes an issue when the payment is "straight" when using 3DS.
