### PR TITLE
Added 3DS callback handler

### DIFF
--- a/.atoum.bootstrap.php
+++ b/.atoum.bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';

--- a/.atoum.php
+++ b/.atoum.php
@@ -1,0 +1,11 @@
+<?php
+
+use \mageekguy\atoum;
+
+$runner->addTestsFromDirectory(__DIR__.'/Tests/Units');
+
+$cliReport = $script->addDefaultReport();
+$cliReport->addField(new atoum\report\fields\runner\result\logo());
+$runner->addReport($cliReport);
+
+$script->bootstrapFile(__DIR__ . DIRECTORY_SEPARATOR . '.atoum.bootstrap.php');

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - COMPOSER_ROOT_VERSION=dev-master php composer.phar install --dev
 
 script:
-  - bin/atoum -d Tests/Units
+  - bin/atoum
 
 notifications:
   email:

--- a/Callback/Callback3dsRequest.php
+++ b/Callback/Callback3dsRequest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Callback;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Represents a Be2bill 3DS callback request.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class Callback3dsRequest
+{
+    private $execCode;
+    private $transactionId;
+    private $orderId;
+    private $message;
+
+    /**
+     * Creates a new request.
+     *
+     * @param string $execCode
+     * @param string $transactionId
+     * @param string $orderId
+     * @param string $message
+     */
+    public function __construct($execCode, $transactionId, $orderId, $message)
+    {
+        $this->execCode = $execCode;
+        $this->transactionId = $transactionId;
+        $this->orderId = $orderId;
+        $this->message = $message;
+    }
+
+    /**
+     * Creates a callback request from an HTTP request.
+     *
+     * @param Request $request
+     *
+     * @return Callback3dsRequest
+     */
+    public static function createFromRequest(Request $request)
+    {
+        return new self(
+            $request->query->get('EXECCODE'),
+            $request->query->get('TRANSACTIONID'),
+            $request->query->get('ORDERID'),
+            $request->query->get('MESSAGE')
+        );
+    }
+
+    /**
+     * Tells if the request is successful.
+     *
+     * @return bool
+     */
+    public function isSuccess()
+    {
+        return '0000' === $this->execCode;
+    }
+
+    /**
+     * Gets the exec code.
+     *
+     * @return string
+     */
+    public function getExecCode()
+    {
+        return $this->execCode;
+    }
+
+    /**
+     * Gets the transaction id.
+     *
+     * @return string
+     */
+    public function getTransactionId()
+    {
+        return $this->transactionId;
+    }
+
+    /**
+     * Gets the order id.
+     *
+     * @return string
+     */
+    public function getOrderId()
+    {
+        return $this->orderId;
+    }
+
+    /**
+     * Gets the message.
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/Callback/Controller/AbstractCallback3dsController.php
+++ b/Callback/Controller/AbstractCallback3dsController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Callback\Controller;
+
+use JMS\Payment\CoreBundle\Model\FinancialTransactionInterface;
+use Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest;
+use JMS\Payment\CoreBundle\Model\PaymentInterface;
+use JMS\Payment\CoreBundle\Plugin\PluginInterface;
+
+/**
+ * Base class for 3DS callback controllers.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+abstract class AbstractCallback3dsController implements Callback3dsControllerInterface
+{
+    /**
+     * Performs the approval and deposit of a 3DS callback request.
+     *
+     * @param Callback3dsRequest            $request
+     * @param FinancialTransactionInterface $transaction
+     *
+     * @throws \RuntimeException
+     */
+    protected function doApproveAndDeposit(Callback3dsRequest $request, FinancialTransactionInterface $transaction)
+    {
+        if (FinancialTransactionInterface::STATE_PENDING !== $transaction->getState()) {
+            throw new \RuntimeException('The financial transaction must be pending.');
+        }
+
+        if ($request->isSuccess()) {
+            $this->deposit($transaction);
+        } else {
+            $this->fail($transaction, $request);
+        }
+    }
+
+    /**
+     * Marks the transaction and related payment failed.
+     *
+     * @param FinancialTransactionInterface $transaction
+     * @param Callback3dsRequest            $request
+     */
+    private function fail(FinancialTransactionInterface $transaction, Callback3dsRequest $request)
+    {
+        $payment = $transaction->getPayment();
+        $instruction = $payment->getPaymentInstruction();
+
+        $payment->setState(PaymentInterface::STATE_FAILED);
+        $payment->setApprovingAmount(0.0);
+        $payment->setDepositingAmount(0.0);
+
+        $instruction->setApprovingAmount(0.0);
+        $instruction->setDepositingAmount(0.0);
+
+        $transaction->setState(FinancialTransactionInterface::STATE_FAILED);
+        $transaction->setResponseCode($request->getExecCode());
+        $transaction->setReasonCode($request->getMessage());
+    }
+
+    /**
+     * Marks the transaction and related payment deposited.
+     *
+     * @param FinancialTransactionInterface $transaction
+     */
+    private function deposit(FinancialTransactionInterface $transaction)
+    {
+        $payment = $transaction->getPayment();
+        $instruction = $payment->getPaymentInstruction();
+        $processedAmount = $transaction->getProcessedAmount();
+
+        $payment->setState(PaymentInterface::STATE_DEPOSITED);
+        $payment->setApprovingAmount(0.0);
+        $payment->setDepositingAmount(0.0);
+        $payment->setApprovedAmount($processedAmount);
+        $payment->setDepositedAmount($processedAmount);
+
+        $instruction->setApprovingAmount(0.0);
+        $instruction->setDepositingAmount(0.0);
+        $instruction->setApprovedAmount($processedAmount);
+        $instruction->setDepositedAmount($processedAmount);
+
+        $transaction->setState(FinancialTransactionInterface::STATE_SUCCESS);
+        $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_SUCCESS);
+        $transaction->setReasonCode(PluginInterface::REASON_CODE_SUCCESS);
+    }
+}

--- a/Callback/Controller/Callback3dsControllerInterface.php
+++ b/Callback/Controller/Callback3dsControllerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Callback\Controller;
+
+use Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest;
+
+/**
+ * Interface for 3DS callback controllers.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+interface Callback3dsControllerInterface
+{
+    /**
+     * Approves an deposits a 3DS callback request.
+     *
+     * @param Callback3dsRequest $request
+     *
+     * @throws \Exception
+     */
+    public function approveAndDeposit(Callback3dsRequest $request);
+}

--- a/Callback/Controller/EntityCallback3dsController.php
+++ b/Callback/Controller/EntityCallback3dsController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Callback\Controller;
+
+use JMS\Payment\CoreBundle\Model\FinancialTransactionInterface;
+use Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Doctrine\ORM\EntityManager;
+
+/**
+ * Handles a 3DS callback and persist the result with an EntityManager.
+ *
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class EntityCallback3dsController extends AbstractCallback3dsController
+{
+    private $entityManager;
+    private $transactionClass;
+
+    /**
+     * Constructor.
+     *
+     * @param EntityManager $entityManager
+     * @param string        $transactionClass
+     */
+    public function __construct(EntityManager $entityManager, $transactionClass)
+    {
+        $this->entityManager = $entityManager;
+        $this->transactionClass = $transactionClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function approveAndDeposit(Callback3dsRequest $request)
+    {
+        $transaction = $this->entityManager->getRepository($this->transactionClass)
+            ->findOneBy(array('trackingId' => $request->getTransactionId()));
+
+        if (!$transaction instanceof FinancialTransactionInterface) {
+            throw new NotFoundHttpException(sprintf(
+                'Cannot find the transaction with tracking id "%s"',
+                $request->getTransactionId()
+            ));
+        }
+
+        $this->doApproveAndDeposit($request, $transaction);
+
+        $this->entityManager->getConnection()->beginTransaction();
+
+        try {
+            $this->entityManager->persist($transaction);
+            $this->entityManager->persist($transaction->getPayment());
+            $this->entityManager->persist($transaction->getPayment()->getPaymentInstruction());
+
+            $this->entityManager->flush();
+            $this->entityManager->getConnection()->commit();
+        } catch (\Exception $e) {
+            $this->entityManager->getConnection()->rollback();
+            $this->entityManager->close();
+
+            throw $e;
+        }
+    }
+}

--- a/DependencyInjection/RezzzaPaymentBe2billExtension.php
+++ b/DependencyInjection/RezzzaPaymentBe2billExtension.php
@@ -33,6 +33,7 @@ class RezzzaPaymentBe2billExtension extends Extension
 
         $xmlLoader->load('client.xml');
         $xmlLoader->load('gateway.xml');
+        $xmlLoader->load('callback.xml');
 
         $container->setParameter('payment.be2bill.debug', $config['debug']);
         $container->setParameter('payment.be2bill.identifier', $config['identifier']);

--- a/Resources/config/callback.xml
+++ b/Resources/config/callback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="payment.be2bill.callback.3ds_controller.class">Rezzza\PaymentBe2billBundle\Callback\Controller\EntityCallback3dsController</parameter>
+    </parameters>
+
+    <services>
+        <service id="payment.be2bill.callback.3ds_controller" class="%payment.be2bill.callback.3ds_controller.class%">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument>%payment.plugin_controller.entity.options.financial_transaction_class%</argument>
+        </service>
+    </services>
+
+</container>

--- a/Tests/Units/Callback/Callback3dsRequest.php
+++ b/Tests/Units/Callback/Callback3dsRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Tests\Units\Callback;
+
+use mageekguy\atoum;
+use Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest as TestedRequest;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * This file is part of the RezzzaPaymentBe2billBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+/**
+ * Callback3dsRequest.
+ *
+ * @uses atoum\test
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class Callback3dsRequest extends atoum\test
+{
+    public function testCreateFromRequest()
+    {
+        $request = new Request(array(
+            'EXECCODE' => '0000',
+            'TRANSACTIONID' => '123',
+            'ORDERID' => '456',
+            'MESSAGE' => 'foo'
+        ));
+
+        $this
+            ->if($callback3dsRequest = TestedRequest::createFromRequest($request))
+            ->string($callback3dsRequest->getExecCode())
+                ->isEqualTo('0000')
+            ->string($callback3dsRequest->getTransactionId())
+                ->isEqualTo('123')
+            ->string($callback3dsRequest->getOrderId())
+                ->isEqualTo('456')
+            ->string($callback3dsRequest->getMessage())
+                ->isEqualTo('foo')
+        ;
+    }
+
+    public function testIsSuccess()
+    {
+        $this
+            ->if($callback3dsRequest = new TestedRequest('0000', null, null, null))
+            ->boolean($callback3dsRequest->isSuccess())
+                ->isTrue()
+        ;
+
+        $this
+            ->if($callback3dsRequest = new TestedRequest('4008', null, null, null))
+            ->boolean($callback3dsRequest->isSuccess())
+                ->isFalse()
+        ;
+    }
+}

--- a/Tests/Units/Callback/Controller/EntityCallback3dsController.php
+++ b/Tests/Units/Callback/Controller/EntityCallback3dsController.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Rezzza\PaymentBe2billBundle\Tests\Units\Callback\Controller;
+
+use JMS\Payment\CoreBundle\Model\FinancialTransactionInterface;
+use JMS\Payment\CoreBundle\Model\PaymentInterface;
+use JMS\Payment\CoreBundle\Plugin\PluginInterface;
+use mageekguy\atoum;
+use Rezzza\PaymentBe2billBundle\Callback\Controller\EntityCallback3dsController as TestedController;
+
+/**
+ * This file is part of the RezzzaPaymentBe2billBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+/**
+ * EntityCallback3dsController.
+ *
+ * @uses atoum\test
+ * @author Florian Voutzinos <florian@voutzinos.com>
+ */
+class EntityCallback3dsController extends atoum\test
+{
+    public function testHandleSuccess()
+    {
+        $processedAmount = 1337;
+        $transactionClass = 'JMS\Payment\CoreBundle\Entity\FinancialTransaction';
+        $transactionId = '1234567';
+
+        // Request
+        $this->mockGenerator->orphanize('__construct');
+        $request = new \mock\Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest();
+        $request->getMockController()->isSuccess = true;
+        $request->getMockController()->getTransactionId = $transactionId;
+
+        // Instruction
+        $instruction = new \mock\JMS\Payment\CoreBundle\Model\PaymentInstructionInterface();
+
+        // Payment
+        $payment = new \mock\JMS\Payment\CoreBundle\Model\PaymentInterface();
+        $payment->getMockController()->getPaymentInstruction = $instruction;
+
+        // Financial transaction
+        $transaction = new \mock\JMS\Payment\CoreBundle\Entity\FinancialTransaction();
+        $transaction->getMockController()->getState = FinancialTransactionInterface::STATE_PENDING;
+        $transaction->getMockController()->getPayment = $payment;
+        $transaction->getMockController()->getProcessedAmount = $processedAmount;
+
+        // Repository
+        $this->mockGenerator->orphanize('__construct');
+        $repository = new \mock\Doctrine\ORM\EntityRepository();
+        $repository->getMockController()->findOneBy = $transaction;
+
+        // Connection
+        $this->mockGenerator->orphanize('__construct');
+        $connection = new \mock\Doctrine\DBAL\Connection();
+        $connection->getMockController()->beginTransaction = function () {};
+        $connection->getMockController()->commit = function () {};
+
+        // Entity manager
+        $this->mockGenerator->orphanize('__construct');
+        $entityManager = new \mock\Doctrine\ORM\EntityManager();
+        $entityManager->getMockController()->getRepository = $repository;
+        $entityManager->getMockController()->getConnection = $connection;
+
+        $this
+            ->if(
+                $handler = new TestedController($entityManager, $transactionClass),
+                $handler->approveAndDeposit($request)
+            )
+            ->mock($repository)
+                ->call('findOneBy')
+                    ->once()
+                    ->withIdenticalArguments(array('trackingId' => $transactionId))
+            ->mock($payment)
+                ->call('setState')
+                    ->once()
+                    ->withIdenticalArguments(PaymentInterface::STATE_DEPOSITED)
+                ->call('setApprovingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setDepositingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setApprovedAmount')
+                    ->once()
+                    ->withIdenticalArguments($processedAmount)
+                ->call('setDepositedAmount')
+                    ->once()
+                    ->withIdenticalArguments($processedAmount)
+            ->mock($instruction)
+                ->call('setApprovingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setDepositingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setApprovedAmount')
+                    ->once()
+                    ->withIdenticalArguments($processedAmount)
+                ->call('setDepositedAmount')
+                    ->once()
+                    ->withIdenticalArguments($processedAmount)
+            ->mock($transaction)
+                ->call('setState')
+                    ->once()
+                    ->withIdenticalArguments(FinancialTransactionInterface::STATE_SUCCESS)
+                ->call('setResponseCode')
+                    ->once()
+                    ->withIdenticalArguments(PluginInterface::RESPONSE_CODE_SUCCESS)
+                ->call('setReasonCode')
+                    ->once()
+                    ->withIdenticalArguments(PluginInterface::REASON_CODE_SUCCESS)
+            ->mock($connection)
+                ->call('beginTransaction')
+                    ->once()
+                ->call('commit')
+                    ->once()
+            ->mock($entityManager)
+                ->call('persist')
+                    ->withIdenticalArguments($payment)
+                    ->once()
+                    ->withIdenticalArguments($instruction)
+                    ->once()
+                    ->withIdenticalArguments($transaction)
+                    ->once()
+                ->call('flush')
+                    ->once()
+        ;
+    }
+
+    public function testHandleFailure()
+    {
+        $transactionClass = 'JMS\Payment\CoreBundle\Entity\FinancialTransaction';
+        $transactionId = '1234567';
+        $execCode = '0048';
+        $message = 'hello';
+
+        // Request
+        $this->mockGenerator->orphanize('__construct');
+        $request = new \mock\Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest();
+        $request->getMockController()->isSuccess = false;
+        $request->getMockController()->getTransactionId = $transactionId;
+        $request->getMockController()->getExecCode = $execCode;
+        $request->getMockController()->getMessage = $message;
+
+        // Instruction
+        $instruction = new \mock\JMS\Payment\CoreBundle\Model\PaymentInstructionInterface();
+
+        // Payment
+        $payment = new \mock\JMS\Payment\CoreBundle\Model\PaymentInterface();
+        $payment->getMockController()->getPaymentInstruction = $instruction;
+
+        // Financial transaction
+        $transaction = new \mock\JMS\Payment\CoreBundle\Entity\FinancialTransaction();
+        $transaction->getMockController()->getState = FinancialTransactionInterface::STATE_PENDING;
+        $transaction->getMockController()->getPayment = $payment;
+
+        // Repository
+        $this->mockGenerator->orphanize('__construct');
+        $repository = new \mock\Doctrine\ORM\EntityRepository();
+        $repository->getMockController()->findOneBy = $transaction;
+
+        // Connection
+        $this->mockGenerator->orphanize('__construct');
+        $connection = new \mock\Doctrine\DBAL\Connection();
+        $connection->getMockController()->beginTransaction = function () {};
+        $connection->getMockController()->commit = function () {};
+
+        // Entity manager
+        $this->mockGenerator->orphanize('__construct');
+        $entityManager = new \mock\Doctrine\ORM\EntityManager();
+        $entityManager->getMockController()->getRepository = $repository;
+        $entityManager->getMockController()->getConnection = $connection;
+
+        $this
+            ->if(
+                $handler = new TestedController($entityManager, $transactionClass),
+                $handler->approveAndDeposit($request)
+            )
+            ->mock($repository)
+                ->call('findOneBy')
+                    ->once()
+                    ->withIdenticalArguments(array('trackingId' => $transactionId))
+            ->mock($payment)
+                ->call('setState')
+                    ->once()
+                    ->withIdenticalArguments(PaymentInterface::STATE_FAILED)
+                ->call('setApprovingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setDepositingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+            ->mock($instruction)
+                ->call('setApprovingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+                ->call('setDepositingAmount')
+                    ->once()
+                    ->withIdenticalArguments(0.0)
+            ->mock($transaction)
+                ->call('setState')
+                    ->once()
+                    ->withIdenticalArguments(FinancialTransactionInterface::STATE_FAILED)
+                ->call('setResponseCode')
+                    ->once()
+                    ->withIdenticalArguments($execCode)
+                ->call('setReasonCode')
+                    ->once()
+                    ->withIdenticalArguments($message)
+            ->mock($connection)
+                ->call('beginTransaction')
+                    ->once()
+                ->call('commit')
+                    ->once()
+            ->mock($entityManager)
+                ->call('persist')
+                    ->withIdenticalArguments($payment)
+                    ->once()
+                    ->withIdenticalArguments($instruction)
+                    ->once()
+                    ->withIdenticalArguments($transaction)
+                    ->once()
+                ->call('flush')
+                    ->once()
+        ;
+    }
+
+    public function testHandleNonPendingTransaction()
+    {
+        // Request
+        $this->mockGenerator->orphanize('__construct');
+        $request = new \mock\Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest();
+
+        // Financial transaction
+        $transaction = new \mock\JMS\Payment\CoreBundle\Entity\FinancialTransaction();
+        $transaction->getMockController()->getState = FinancialTransactionInterface::STATE_SUCCESS;
+
+        // Repository
+        $this->mockGenerator->orphanize('__construct');
+        $repository = new \mock\Doctrine\ORM\EntityRepository();
+        $repository->getMockController()->findOneBy = $transaction;
+
+        // Entity manager
+        $this->mockGenerator->orphanize('__construct');
+        $entityManager = new \mock\Doctrine\ORM\EntityManager();
+        $entityManager->getMockController()->getRepository = $repository;
+
+        $this
+            ->if($handler = new TestedController($entityManager, ''))
+            ->exception(function () use ($handler, $request) {
+                $handler->approveAndDeposit($request);
+            })
+        ;
+    }
+
+    public function testHandleUnexistingTransaction()
+    {
+        // Request
+        $this->mockGenerator->orphanize('__construct');
+        $request = new \mock\Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest();
+
+        // Repository
+        $this->mockGenerator->orphanize('__construct');
+        $repository = new \mock\Doctrine\ORM\EntityRepository();
+        $repository->getMockController()->findOneBy = null;
+
+        // Entity manager
+        $this->mockGenerator->orphanize('__construct');
+        $entityManager = new \mock\Doctrine\ORM\EntityManager();
+        $entityManager->getMockController()->getRepository = $repository;
+
+        $this
+            ->if($handler = new TestedController($entityManager, ''))
+            ->exception(function () use ($handler, $request) {
+                $handler->approveAndDeposit($request);
+            })
+        ;
+    }
+}

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -2,8 +2,6 @@
 
 namespace Rezzza\PaymentBe2billBundle\Tests\Units\Client;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use Rezzza\PaymentBe2billBundle\Client\Client as TestedClient;
 

--- a/Tests/Units/Client/Response.php
+++ b/Tests/Units/Client/Response.php
@@ -2,8 +2,6 @@
 
 namespace Rezzza\PaymentBe2billBundle\Tests\Units\Client;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use Rezzza\PaymentBe2billBundle\Client\Response as TestedResponse;
 

--- a/Tests/Units/DependencyInjection/RezzzaPaymentBe2billExtension.php
+++ b/Tests/Units/DependencyInjection/RezzzaPaymentBe2billExtension.php
@@ -2,11 +2,10 @@
 
 namespace Rezzza\PaymentBe2billBundle\Tests\Units\DependencyInjection;
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
 use mageekguy\atoum;
 use Rezzza\PaymentBe2billBundle\DependencyInjection\RezzzaPaymentBe2billExtension as TestedExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This file is part of the RezzzaPaymentBe2billBundle package.
@@ -27,9 +26,10 @@ class RezzzaPaymentBe2billExtension extends atoum\test
     public function testCreateClientDefaultDisplayMode()
     {
         $this
-            ->if($container = new ContainerBuilder())
-            ->and($extension = new TestedExtension())
-            ->and($config = array('rezzza_payment_be2bill' =>
+            ->if(
+                $container = new ContainerBuilder(),
+                $extension = new TestedExtension(),
+                $config = array('rezzza_payment_be2bill' =>
                 array('identifier' => 'test', 'password' => 'test')
             ))
             ->and($extension->load($config, $container))
@@ -45,9 +45,10 @@ class RezzzaPaymentBe2billExtension extends atoum\test
     public function testCreateCient()
     {
         $this
-            ->if($container = new ContainerBuilder())
-            ->and($extension = new TestedExtension())
-            ->and($config = array('rezzza_payment_be2bill' =>
+            ->if(
+                $container = new ContainerBuilder(),
+                $extension = new TestedExtension(),
+                $config = array('rezzza_payment_be2bill' =>
                 array('identifier' => 'test', 'password' => 'test', 'default_3ds_display_mode' => 'popup')
             ))
             ->and($extension->load($config, $container))
@@ -63,14 +64,39 @@ class RezzzaPaymentBe2billExtension extends atoum\test
     public function testCreateCientInvalidDisplayMode()
     {
         $this
-            ->if($container = new ContainerBuilder())
-            ->and($config = array('rezzza_payment_be2bill' =>
+            ->if(
+                $container = new ContainerBuilder(),
+                $config = array('rezzza_payment_be2bill' =>
                 array('identifier' => 'test', 'password' => 'test', 'default_3ds_display_mode' => 'INVALID')
             ))
             ->and($extension = new TestedExtension())
                 ->exception(function () use ($extension, $config, $container) {
                     $extension->load($config, $container);
                 })
+        ;
+    }
+
+    public function testCallback3dsHandler()
+    {
+        $this
+            ->if(
+                $container = new ContainerBuilder(),
+                $extension = new TestedExtension(),
+                $config = array('rezzza_payment_be2bill' =>
+                    array('identifier' => 'test', 'password' => 'test')
+                ),
+                $extension->load($config, $container),
+                $definition = $container->getDefinition('payment.be2bill.callback.3ds_controller'),
+                $class = $container->getParameter('payment.be2bill.callback.3ds_controller.class')
+            )
+            ->string($class)
+                ->isEqualTo('Rezzza\PaymentBe2billBundle\Callback\Controller\EntityCallback3dsController')
+            ->string($definition->getClass())
+                ->isEqualTo('%payment.be2bill.callback.3ds_controller.class%')
+            ->object($definition->getArgument(0))
+                ->isEqualTo(new Reference('doctrine.orm.entity_manager'))
+            ->string($definition->getArgument(1))
+                ->isEqualTo('%payment.plugin_controller.entity.options.financial_transaction_class%')
         ;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "jms/payment-core-bundle": "~1.0"
     },
     "require-dev": {
-        "atoum/atoum-bundle": "dev-master"
+        "atoum/atoum-bundle": "dev-master",
+        "doctrine/orm": "*"
     },
     "autoload":     {
         "psr-0": { "Rezzza\\PaymentBe2billBundle": "" }


### PR DESCRIPTION
``` php
namespace Acme\DemoBundle\Controller;

use Rezzza\PaymentBe2billBundle\Callback\Callback3dsRequest;
use Symfony\Component\HttpFoundation\Request;

class SomeController
{
    public function callbackAction(Request $request)
    {
        $callbackRequest = Callback3dsRequest::createFromRequest($request);

        try {
            $this
                ->get('payment.be2bill.callback.3ds_controller')
                ->approveAndDeposit($callbackRequest);
        } catch (\Exception $e) {
            // Maybe you can log the exception somewhere
        }

       // Do some stuff with the values
       $callbackRequest->getOrderId();
       $callbackRequest->getTransactionId();
    }
}
```

The handler will fetch the corresponding `FinancialTransation` from the `TransactionId` sent by Be2bill in their callback, update the models states and save them.
