### PR TITLE
Use round instead of intval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.5
   - 5.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.5
   - 5.6
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: php
 
+
+dist: trusty
+sudo: false
+
 php:
   - 5.5
   - 5.6
 
+before_install:
+    - |
+      # php.ini configuration
+      INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+      phpenv config-rm xdebug.ini || echo "xdebug not available"
+      echo date.timezone = Europe/Paris >> $INI
+      echo memory_limit = -1 >> $INI
+      echo session.gc_probability = 0 >> $INI
+      echo opcache.enable_cli = 1 >> $INI
+
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - COMPOSER_ROOT_VERSION=dev-master php composer.phar install --dev
+  - composer install --dev
 
 script:
   - bin/atoum

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: false
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 before_install:
     - |

--- a/Client/Client.php
+++ b/Client/Client.php
@@ -171,6 +171,6 @@ class Client
 
     private function convertAmountToBe2billFormat($amount)
     {
-        return intval($amount * 100);
+        return round($amount * 100, 0, PHP_ROUND_HALF_DOWN);
     }
 }

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -38,8 +38,8 @@ class Client extends atoum\test
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
                 $this->addGuzzleMockResponses(array(
-                    new \Guzzle\Http\Message\Response(200),
-                    new \Guzzle\Http\Message\Response(200)
+                    new \Guzzle\Http\Message\Response(200, null, '{}'),
+                    new \Guzzle\Http\Message\Response(200, null, '{}')
                 ))
             )
             ->when(
@@ -71,8 +71,8 @@ class Client extends atoum\test
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
                 $this->addGuzzleMockResponses(array(
-                    new \Guzzle\Http\Message\Response(500),
-                    new \Guzzle\Http\Message\Response(200)
+                    new \Guzzle\Http\Message\Response(500, null, '{}'),
+                    new \Guzzle\Http\Message\Response(200, null, '{}')
                 ))
             )
             ->when(
@@ -118,8 +118,8 @@ class Client extends atoum\test
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
                 $this->addGuzzleMockResponses(array(
-                    new \Guzzle\Http\Message\Response(500),
-                    new \Guzzle\Http\Message\Response(403)
+                    new \Guzzle\Http\Message\Response(500, null, '{}'),
+                    new \Guzzle\Http\Message\Response(403, null, '{}')
                 ))
             )
             ->exception(
@@ -168,7 +168,7 @@ class Client extends atoum\test
             ->given(
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
-                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
+                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200, null, '{}')))
             )
             ->when(
                 $response = $client->requestRefund(array(
@@ -200,7 +200,7 @@ class Client extends atoum\test
             ->given(
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
-                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
+                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200, null, '{}')))
             )
             ->when(
                 $response = $client->requestPayment(array(
@@ -234,7 +234,7 @@ class Client extends atoum\test
             ->given(
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
-                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
+                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200, null, '{}')))
             )
             ->when(
                 $response = $client->requestPayment(array(
@@ -268,12 +268,12 @@ class Client extends atoum\test
     {
         $this->hashGenerator = new \mock\Rezzza\PaymentBe2billBundle\Client\ParametersHashGenerator('CuirMoustache');
         $this->httpClient = new \mock\Guzzle\Http\Client;
-        
+
         $this
             ->given(
                 $this->hashGenerator->getMockController()->hash = 'HASH',
                 $client = new TestedClient($this->httpClient, 'CHUCKNORRIS', $this->hashGenerator, true, 'main'),
-                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
+                $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200, null, '{}')))
             )
             ->when(
                 $response = $client->requestPayment(array('AMOUNT' => $amount))

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -299,11 +299,11 @@ class Client extends atoum\test
 
     protected function amountsDataProvider()
     {
-        return [
-            [1.05, 105],
-            [8.20, 820],
-            [42.63, 4263],
-        ];
+        return array(
+            array(1.05, 105),
+            array(8.20, 820),
+            array(42.63, 4263),
+        );
     }
 
     private function addGuzzleMockResponses(array $responses)

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -261,8 +261,14 @@ class Client extends atoum\test
         ;
     }
 
-    public function test_it_should_convert_amount()
+    /**
+     * @dataProvider amountsDataProvider
+     */
+    public function test_it_should_convert_amount($amount, $convertedAmount)
     {
+        $this->hashGenerator = new \mock\Rezzza\PaymentBe2billBundle\Client\ParametersHashGenerator('CuirMoustache');
+        $this->httpClient = new \mock\Guzzle\Http\Client;
+        
         $this
             ->given(
                 $this->hashGenerator->getMockController()->hash = 'HASH',
@@ -270,7 +276,7 @@ class Client extends atoum\test
                 $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
             )
             ->when(
-                $response = $client->requestPayment(array('AMOUNT' => 8.20))
+                $response = $client->requestPayment(array('AMOUNT' => $amount))
             )
             ->mock($this->httpClient)
                 ->call('post')
@@ -280,7 +286,7 @@ class Client extends atoum\test
                         array(
                             'method' => 'payment',
                             'params' => array(
-                                'AMOUNT' => 820,
+                                'AMOUNT' => $convertedAmount,
                                 'IDENTIFIER' => 'CHUCKNORRIS',
                                 'OPERATIONTYPE' => 'payment',
                                 'HASH' => 'HASH'
@@ -289,6 +295,15 @@ class Client extends atoum\test
                     )
                     ->once()
         ;
+    }
+
+    protected function amountsDataProvider()
+    {
+        return [
+            [1.05, 105],
+            [8.20, 820],
+            [42.63, 4263],
+        ];
     }
 
     private function addGuzzleMockResponses(array $responses)

--- a/Tests/Units/Client/Client.php
+++ b/Tests/Units/Client/Client.php
@@ -270,7 +270,7 @@ class Client extends atoum\test
                 $this->addGuzzleMockResponses(array(new \Guzzle\Http\Message\Response(200)))
             )
             ->when(
-                $response = $client->requestPayment(array('AMOUNT' => 1.05))
+                $response = $client->requestPayment(array('AMOUNT' => 8.20))
             )
             ->mock($this->httpClient)
                 ->call('post')
@@ -280,7 +280,7 @@ class Client extends atoum\test
                         array(
                             'method' => 'payment',
                             'params' => array(
-                                'AMOUNT' => 105,
+                                'AMOUNT' => 820,
                                 'IDENTIFIER' => 'CHUCKNORRIS',
                                 'OPERATIONTYPE' => 'payment',
                                 'HASH' => 'HASH'

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "homepage": "https://github.com/rezzza/PaymentBe2billBundle/contributors"
     }],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.6.0,<7.2",
         "symfony/framework-bundle": "~2.0|~3.0",
         "jms/payment-core-bundle": "~1.0",
         "guzzle/http": "~3.1"
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0",
+        "symfony/framework-bundle": "~2.0|~3.0",
         "jms/payment-core-bundle": "~1.0",
         "guzzle/http": "~3.1"
     },


### PR DESCRIPTION
Fix  #33

Require a major release bump as php5.3 is deprecated.